### PR TITLE
Update override_weapons.xml

### DIFF
--- a/override_weapons.xml
+++ b/override_weapons.xml
@@ -7227,8 +7227,8 @@
       <mode>SS</mode>
       <rc>0</rc>
       <ammo>6(c)</ammo>
-      <avail>0</avail>
-      <cost>0</cost>
+      <avail>10F</avail>
+      <cost>3500	</cost>
       <source>SR5</source>
       <page>428</page>
       <accessorymounts>
@@ -7307,8 +7307,8 @@
       <mode>SS</mode>
       <rc>0</rc>
       <ammo>1(ml)</ammo>
-      <avail>0</avail>
-      <cost>0</cost>
+      <avail>8R</avail>
+      <cost>600</cost>
       <source>SR5</source>
       <page>449</page>
       <range>Light Crossbows</range>


### PR DESCRIPTION
Applies the proper availability and costs to underbarrel grenade launchers and grapple guns as per Run & Gun.